### PR TITLE
Tidy up workflow and add auto-approve flow for dependabot

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,10 +34,6 @@
                 "varsIgnorePattern": "^_*$"
             }
         ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
         "semi": [
             "error",
             "always"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,11 @@
+name: Auto approve
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: hmarr/auto-approve-action@v2.0.0
+      if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,10 +2,11 @@ name: Auto approve
 on: pull_request
 
 jobs:
-  build:
+  approve:
+    name: Auto-approve dependabot PRs
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     steps:
     - uses: hmarr/auto-approve-action@v2.0.0
-      if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macOS-latest]
-        node-version: [8.x, 10.x, 12.x]
+        os: [ubuntu-latest]
+        node-version: [12.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}
@@ -29,16 +29,13 @@ jobs:
       run: yarn install
     - name: Lint
       run: yarn lint
-      if: matrix.os != 'windows-latest'
-    - name: Lint
-      run: "yarn lint --rule 'linebreak-style: 0'"
-      if: matrix.os == 'windows-latest'
     - name: Flow
       run: yarn flow:ci
 
 
-  build_and_test:
-    name: Build and test
+  test_and_build:
+    needs: [coverage, lint]
+    name: Test and build
     env:
       CI: true
     runs-on: ${{ matrix.os }}
@@ -54,7 +51,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies
       run: yarn install
-    - name: Build dist
+    - name: Run tests and build
       run: yarn build
 
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,28 +33,6 @@ jobs:
       run: yarn flow:ci
 
 
-  test_and_build:
-    needs: [coverage, lint]
-    name: Test and build
-    env:
-      CI: true
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest, macOS-latest]
-        node-version: [8.x, 10.x, 12.x]
-    steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install dependencies
-      run: yarn install
-    - name: Run tests and build
-      run: yarn build
-
-
   coverage:
     name: Update test coverage
     env:
@@ -75,3 +53,24 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+
+  test_and_build:
+    needs: [coverage, lint]
+    name: Test and build
+    env:
+      CI: true
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macOS-latest]
+        node-version: [8.x, 10.x, 12.x]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: yarn install
+    - name: Run tests and build
+      run: yarn build

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,6 +29,10 @@ jobs:
       run: yarn install
     - name: Lint
       run: yarn lint
+      if: matrix.os != windows-latest
+    - name: Lint
+      run: "yarn lint --rule 'linebreak-style: 0'"
+      if: matrix.os == windows-latest
     - name: Flow
       run: yarn flow:ci
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,10 +29,10 @@ jobs:
       run: yarn install
     - name: Lint
       run: yarn lint
-      if: matrix.os != windows-latest
+      if: matrix.os != "windows-latest"
     - name: Lint
       run: "yarn lint --rule 'linebreak-style: 0'"
-      if: matrix.os == windows-latest
+      if: matrix.os == "windows-latest"
     - name: Flow
       run: yarn flow:ci
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,8 @@ on:
     - master
 
 jobs:
-  install:
+  lint:
+    name: Lint and flow check
     env:
       CI: true
     runs-on: ${{ matrix.os }}
@@ -26,44 +27,46 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies
       run: yarn install
-
-
-  lint:
-    env:
-      CI: true
-    needs: install
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest, macOS-latest]
-        node-version: [8.x, 10.x, 12.x]
-    steps:
     - name: Lint
       run: yarn lint
     - name: Flow
       run: yarn flow:ci
 
 
-  build:
+  build_and_test:
+    name: Build and test
     env:
       CI: true
-    needs: install
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
         node-version: [8.x, 10.x, 12.x]
     steps:
-      - name: Build dist
-        run: yarn build
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: yarn install
+    - name: Build dist
+      run: yarn build
 
 
   coverage:
+    name: Update test coverage
     env:
       CI: true
-    needs: install
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install dependencies
+      run: yarn install
     - name: Run tests with coverage
       run: yarn coverage
     - name: Upload coverage

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,10 +29,10 @@ jobs:
       run: yarn install
     - name: Lint
       run: yarn lint
-      if: matrix.os != "windows-latest"
+      if: matrix.os != 'windows-latest'
     - name: Lint
       run: "yarn lint --rule 'linebreak-style: 0'"
-      if: matrix.os == "windows-latest"
+      if: matrix.os == 'windows-latest'
     - name: Flow
       run: yarn flow:ci
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   install:
+    env:
+      CI: true
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -27,6 +29,8 @@ jobs:
 
 
   lint:
+    env:
+      CI: true
     needs: install
     runs-on: ${{ matrix.os }}
     strategy:
@@ -41,6 +45,8 @@ jobs:
 
 
   build:
+    env:
+      CI: true
     needs: install
     runs-on: ${{ matrix.os }}
     strategy:
@@ -50,22 +56,19 @@ jobs:
     steps:
       - name: Build dist
         run: yarn build
-        env:
-          CI: true
 
 
   coverage:
+    env:
+      CI: true
     needs: install
     runs-on: ubuntu-latest
     node-version: 12.x
     steps:
     - name: Run tests with coverage
       run: yarn coverage
-      env:
-        CI: true
     - name: Upload coverage
       run: yarn codecov
       env:
-        CI: true
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -63,7 +63,6 @@ jobs:
       CI: true
     needs: install
     runs-on: ubuntu-latest
-    node-version: 12.x
     steps:
     - name: Run tests with coverage
       run: yarn coverage

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,18 +10,12 @@ on:
     - master
 
 jobs:
-  test:
+  install:
     runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
         node-version: [8.x, 10.x, 12.x]
-        include:
-          - os: ubuntu-latest
-            node-version: 12.x
-            coverage: true
-
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}
@@ -30,22 +24,48 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies
       run: yarn install
-    - name: Lint & Flow
-      run: yarn lint && yarn flow:ci
-      if: matrix.coverage
-    - name: Run tests
-      run: yarn test
-      if: matrix.coverage != true
-      env:
-        CI: true
+
+
+  lint:
+    needs: install
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macOS-latest]
+        node-version: [8.x, 10.x, 12.x]
+    steps:
+    - name: Lint
+      run: yarn lint
+    - name: Flow
+      run: yarn flow:ci
+
+
+  build:
+    needs: install
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macOS-latest]
+        node-version: [8.x, 10.x, 12.x]
+    steps:
+      - name: Build dist
+        run: yarn build
+        env:
+          CI: true
+
+
+  coverage:
+    needs: install
+    runs-on: ubuntu-latest
+    node-version: 12.x
+    steps:
     - name: Run tests with coverage
       run: yarn coverage
-      if: matrix.coverage
       env:
         CI: true
     - name: Upload coverage
       run: yarn codecov
-      if: matrix.coverage
       env:
         CI: true
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "pretty-quick": "pretty-quick --staged",
     "flow:ci": "flow check",
     "flow:dev": "flow",
-    "lint": "eslint --report-unused-disable-directives --config .eslintrc.json '{src,bin,__{tests,mocks}__}/**/*.js'"
+    "lint": "eslint --report-unused-disable-directives --config .eslintrc.json \"{src,bin,__{tests,mocks}__}/**/*.js\""
   },
   "pre-commit": [
     "pretty-quick",


### PR DESCRIPTION
This updates our workflow a bit.

1. We run lint/flow and coverage as parallel jobs first
2. Then we run a test and build matrix if those jobs pass

Also adds a new workflow for auto-approving dependabot PRs.