### PR TITLE
Specify node 8 version to workaround Windows issue in Github Actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [^8.12.x, 10.x, 12.x]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
**Summary**
Specify node 8 version to workaround Windows issue in Github Actions

**Issues**
This works around https://github.com/actions/setup-node/issues/27 and https://github.com/actions/virtual-environments/issues/42
