### PR TITLE
Add closesdir function

### DIFF
--- a/.changeset/soft-breads-kneel.md
+++ b/.changeset/soft-breads-kneel.md
@@ -1,0 +1,5 @@
+---
+"ancesdir": minor
+---
+
+NEW: `closesdir` function - this is the same as `ancesdir` except that it will start the search at the beginning location rather than its parent

--- a/src/__tests__/ancesdir.test.ts
+++ b/src/__tests__/ancesdir.test.ts
@@ -27,15 +27,23 @@ describe("ancesdir", () => {
     it("should invoke findMarker with normalized options", () => {
         // Arrange
         const spyFindMarker = jest.spyOn(FindMarker, "findMarker");
-        jest.spyOn(NormalizeOptions, "normalizeOptions").mockReturnValue(
-            "FAKE_OPTIONS" as any,
-        );
+        jest.spyOn(NormalizeOptions, "normalizeOptions").mockReturnValue({
+            from: "/some/path",
+            marker: "marker",
+            includeFrom: true,
+            force: true,
+        });
 
         // Act
         ancesdir("/some/path", "marker");
 
         // Assert
-        expect(spyFindMarker).toHaveBeenCalledWith("FAKE_OPTIONS");
+        expect(spyFindMarker).toHaveBeenCalledWith({
+            from: "/some/path",
+            marker: "marker",
+            includeFrom: false, // ancesdir does not include the starting location in the search
+            force: true,
+        });
     });
 
     it("should return the result of findMarker", () => {

--- a/src/__tests__/closesdir.test.ts
+++ b/src/__tests__/closesdir.test.ts
@@ -2,6 +2,7 @@ import {closesdir} from "../closesdir";
 
 import * as NormalizeOptions from "../normalize-options";
 import * as FindMarker from "../find-marker";
+import * as Defaults from "../defaults";
 
 jest.mock("../normalize-options");
 jest.mock("../find-marker");
@@ -9,10 +10,14 @@ jest.mock("../find-marker");
 describe("closesdir", () => {
     it("should normalize options", () => {
         // Arrange
-        const spyNormalizeOptions = jest.spyOn(
-            NormalizeOptions,
-            "normalizeOptions",
-        );
+        const spyNormalizeOptions = jest
+            .spyOn(NormalizeOptions, "normalizeOptions")
+            .mockReturnValue({
+                from: "/some/path",
+                marker: "marker",
+                includeFrom: false,
+                force: true,
+            });
 
         // Act
         closesdir("/some/path", "marker");
@@ -46,9 +51,39 @@ describe("closesdir", () => {
         });
     });
 
+    it("should call findMarker with the parent of the default folder if the from would be the default folder", () => {
+        // Arrange
+        jest.spyOn(Defaults, "defaultFrom").mockReturnValue(
+            "/default/parent/path",
+        );
+        const spyFindMarker = jest.spyOn(FindMarker, "findMarker");
+        jest.spyOn(NormalizeOptions, "normalizeOptions").mockReturnValue({
+            from: "/default/parent/path",
+            marker: "marker",
+            includeFrom: true,
+            force: true,
+        });
+
+        // Act
+        closesdir();
+
+        // Assert
+        expect(spyFindMarker).toHaveBeenCalledWith(
+            expect.objectContaining({
+                from: "/default/parent",
+            }),
+        );
+    });
+
     it("should return the result of findMarker", () => {
         // Arrange
         jest.spyOn(FindMarker, "findMarker").mockReturnValue("FAKE_RESULT");
+        jest.spyOn(NormalizeOptions, "normalizeOptions").mockReturnValue({
+            from: "/some/path",
+            marker: "marker",
+            includeFrom: false,
+            force: true,
+        });
 
         // Act
         const result = closesdir("/some/path", "marker");

--- a/src/__tests__/closesdir.test.ts
+++ b/src/__tests__/closesdir.test.ts
@@ -1,0 +1,59 @@
+import {closesdir} from "../closesdir";
+
+import * as NormalizeOptions from "../normalize-options";
+import * as FindMarker from "../find-marker";
+
+jest.mock("../normalize-options");
+jest.mock("../find-marker");
+
+describe("closesdir", () => {
+    it("should normalize options", () => {
+        // Arrange
+        const spyNormalizeOptions = jest.spyOn(
+            NormalizeOptions,
+            "normalizeOptions",
+        );
+
+        // Act
+        closesdir("/some/path", "marker");
+
+        // Assert
+        expect(spyNormalizeOptions).toHaveBeenCalledWith(
+            "/some/path",
+            "marker",
+        );
+    });
+
+    it("should invoke findMarker with normalized options and includeFrom=true", () => {
+        // Arrange
+        const spyFindMarker = jest.spyOn(FindMarker, "findMarker");
+        jest.spyOn(NormalizeOptions, "normalizeOptions").mockReturnValue({
+            from: "/some/path",
+            marker: "marker",
+            includeFrom: false,
+            force: true,
+        });
+
+        // Act
+        closesdir("/some/path", "marker");
+
+        // Assert
+        expect(spyFindMarker).toHaveBeenCalledWith({
+            from: "/some/path",
+            marker: "marker",
+            includeFrom: true,
+            force: true,
+        });
+    });
+
+    it("should return the result of findMarker", () => {
+        // Arrange
+        jest.spyOn(FindMarker, "findMarker").mockReturnValue("FAKE_RESULT");
+
+        // Act
+        const result = closesdir("/some/path", "marker");
+
+        // Assert
+        expect(result).toBe("FAKE_RESULT");
+    });
+});

--- a/src/ancesdir.ts
+++ b/src/ancesdir.ts
@@ -2,11 +2,21 @@ import {AncesdirFn, Options} from "./types";
 import {normalizeOptions} from "./normalize-options";
 import {findMarker} from "./find-marker";
 
+/**
+ * Find the ancestral directory containing a specific marker file.
+ *
+ * This function searches for the ancestral directory that contains the
+ * specified marker file, starting with the parent directory of the given path
+ * or the parent directory of ancesdir's package directory.
+ */
 export const ancesdir: AncesdirFn = (
-    fromOrOptions?: string | Partial<Options>,
+    fromOrOptions?: string | Partial<Omit<Options, "includeFrom">>,
     maybeMarker?: string,
 ): string => {
     const options = normalizeOptions(fromOrOptions, maybeMarker);
 
-    return findMarker(options);
+    return findMarker({
+        ...options,
+        includeFrom: false, // ancesdir does not include the starting location in the search
+    });
 };

--- a/src/closesdir.ts
+++ b/src/closesdir.ts
@@ -1,22 +1,30 @@
+import path from "node:path";
 import {findMarker} from "./find-marker";
 import {normalizeOptions} from "./normalize-options";
-import {Options} from "./types";
+import {ClosesdirFn, Options} from "./types";
+import {defaultFrom} from "./defaults";
 
 /**
  * Find the closest directory containing a specific marker file.
  *
  * This function is similar to ancesdir, but it includes the starting
  * directory in the search. It returns the closest directory that contains
- * the specified marker file, starting from the given path or ancesdir's
- * package directory.
+ * the specified marker file, starting from the given path or the parent
+ * directory of ancesdir's package directory.
  */
-export function closesdir(
+export const closesdir: ClosesdirFn = (
     fromOrOptions?: string | Partial<Omit<Options, "includeFrom">>,
     maybeMarker?: string,
-): string {
+): string => {
     const normalizedOptions = normalizeOptions(fromOrOptions, maybeMarker);
+
+    if (normalizedOptions.from === defaultFrom()) {
+        // If no 'from' is provided, use the parent of the defaultFrom folder
+        normalizedOptions.from = path.dirname(normalizedOptions.from);
+    }
+
     return findMarker({
         ...normalizedOptions,
         includeFrom: true,
     });
-}
+};

--- a/src/closesdir.ts
+++ b/src/closesdir.ts
@@ -1,0 +1,22 @@
+import {findMarker} from "./find-marker";
+import {normalizeOptions} from "./normalize-options";
+import {Options} from "./types";
+
+/**
+ * Find the closest directory containing a specific marker file.
+ *
+ * This function is similar to ancesdir, but it includes the starting
+ * directory in the search. It returns the closest directory that contains
+ * the specified marker file, starting from the given path or ancesdir's
+ * package directory.
+ */
+export function closesdir(
+    fromOrOptions?: string | Partial<Omit<Options, "includeFrom">>,
+    maybeMarker?: string,
+): string {
+    const normalizedOptions = normalizeOptions(fromOrOptions, maybeMarker);
+    return findMarker({
+        ...normalizedOptions,
+        includeFrom: true,
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export {ancesdir as default} from "./ancesdir";
+export {closesdir} from "./closesdir";

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,7 @@ export interface AncesdirFn {
      * Finds the ancestral directory containing a specific marker file.
      *
      * Defaults to starting the search in ancesdir's package directory.
-     * The default marker is "package.json". Rhe starting `from`
+     * The default marker is "package.json". The starting `from`
      * location is not included in the search; see {@link closesdir} if you
      * want this behavior.
      *
@@ -91,7 +91,7 @@ export interface ClosesdirFn {
      *
      * Defaults to starting the search in ancesdir's package directory.
      * The default marker is "package.json". The starting `from`
-     * location is included in the search; see {@link ancesdir} if you do no
+     * location is included in the search; see {@link ancesdir} if you do not
      * want this behavior.
      *
      * @param options - An object containing options for the search.

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,14 +56,48 @@ export interface AncesdirFn {
      * Finds the ancestral directory containing a specific marker file.
      *
      * Defaults to starting the search in ancesdir's package directory.
-     * The default marker is "package.json". By default, the starting `from`
-     * location is not included in the search; use the `includeFrom` option to
-     * override this behavior, or use {@link closesdir}.
+     * The default marker is "package.json". Rhe starting `from`
+     * location is not included in the search; see {@link closesdir} if you
+     * want this behavior.
      *
      * @param options - An object containing options for the search.
      * @returns The absolute path to the directory containing the marker file.
      * @throws Error if the marker file is not found in any parent directory.
      * @throws Error if the `from` path is not absolute.
      */
-    (options?: Partial<Options>): string;
+    (options?: Partial<Omit<Options, "includeFrom">>): string;
+}
+
+export interface ClosesdirFn {
+    /**
+     * Finds the closest directory containing a specific marker file.
+     *
+     * This function is similar to ancesdir, except this function includes the
+     * starting `from` location in the search. If you only want to look at
+     * parent directories, @see {@link ancesdir}.
+     *
+     * @param from - The absolute starting directory path. If not provided,
+     * defaults to the package directory of ancesdir.
+     * @param marker - The marker file name to search for. Defaults to
+     * "package.json".
+     * @returns The absolute path to the directory containing the marker file.
+     * @throws Error if the marker file is not found in any parent directory.
+     * @throws Error if the `from` path is not absolute.
+     */
+    (from?: string, marker?: string): string;
+
+    /**
+     * Finds the closest directory containing a specific marker file.
+     *
+     * Defaults to starting the search in ancesdir's package directory.
+     * The default marker is "package.json". The starting `from`
+     * location is included in the search; see {@link ancesdir} if you do no
+     * want this behavior.
+     *
+     * @param options - An object containing options for the search.
+     * @returns The absolute path to the directory containing the marker file.
+     * @throws Error if the marker file is not found in any parent directory.
+     * @throws Error if the `from` path is not absolute.
+     */
+    (options?: Partial<Omit<Options, "includeFrom">>): string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,8 +38,12 @@ export interface AncesdirFn {
     /**
      * Finds the ancestral directory containing a specific marker file.
      *
+     * The starting `from` location is not included in the search.
+     * @see {@link closesdir} for a version that includes the starting
+     * location in the search.
+     *
      * @param from - The absolute starting directory path. If not provided,
-     * defaults to the package directory of the current module.
+     * defaults to the package directory of ancesdir.
      * @param marker - The marker file name to search for. Defaults to
      * "package.json".
      * @returns The absolute path to the directory containing the marker file.
@@ -50,6 +54,11 @@ export interface AncesdirFn {
 
     /**
      * Finds the ancestral directory containing a specific marker file.
+     *
+     * Defaults to starting the search in ancesdir's package directory.
+     * The default marker is "package.json". By default, the starting `from`
+     * location is not included in the search; use the `includeFrom` option to
+     * override this behavior, or use {@link closesdir}.
      *
      * @param options - An object containing options for the search.
      * @returns The absolute path to the directory containing the marker file.

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,7 +77,7 @@ export interface ClosesdirFn {
      * parent directories, @see {@link ancesdir}.
      *
      * @param from - The absolute starting directory path. If not provided,
-     * defaults to the package directory of ancesdir.
+     * defaults to the parent directory of the `ancesdir` package directory.
      * @param marker - The marker file name to search for. Defaults to
      * "package.json".
      * @returns The absolute path to the directory containing the marker file.
@@ -89,10 +89,10 @@ export interface ClosesdirFn {
     /**
      * Finds the closest directory containing a specific marker file.
      *
-     * Defaults to starting the search in ancesdir's package directory.
-     * The default marker is "package.json". The starting `from`
-     * location is included in the search; see {@link ancesdir} if you do not
-     * want this behavior.
+     * Defaults to starting the search in the parent directory of the `ancesdir`
+     * package directory. The default marker is "package.json". The starting
+     * `from` location is included in the search; see {@link ancesdir} if you do
+     * not want this behavior.
      *
      * @param options - An object containing options for the search.
      * @returns The absolute path to the directory containing the marker file.


### PR DESCRIPTION
## Summary:
This adds a new `closesdir` function that allows users to find the closest directory to a given path that contains the given marker file. Unlike, `ancesdir`, this includes the current directory in the search.

Issue: #1917

## Test plan:
`pnpm test`